### PR TITLE
PM Check on Alarm

### DIFF
--- a/AlarmClock_12hr_millis.ino
+++ b/AlarmClock_12hr_millis.ino
@@ -1,8 +1,8 @@
 /*
   :Project:Clock_Alarm
   :Author: Joel Cranmer
-  :Date: 10/30/2019
-  :Revision: 1.5
+  :Date: 1/24/2020
+  :Revision: 1.6
   :License: MIT License
 */
 //************libraries**************//
@@ -467,9 +467,10 @@ void UpdateLEDs()
     if (alarmPM)
     {  AlarmTime = AlarmTime + (12 * 60 * 60); }
     DateTime now = rtc.now();
+    bool nowPM = (now.hour() >= 12);
     uint32_t curTime = (now.hour() * 60 * 60) + (now.minute() * 60) + now.second();
     long diff = curTime - AlarmTime;    
-    if ( digitalRead(AlarmON) == LOW && (diff > AlarmStartAt && diff < AlarmEndAt ))
+    if ( digitalRead(AlarmON) == LOW && (diff > AlarmStartAt && diff < AlarmEndAt ) && alarmPM == nowPM)
     {
       Sunrise(diff-AlarmStartAt);
       AlarmLatch = true; // force "Snooze" to be pressed.


### PR DESCRIPTION
Add check to see if both Alarm and Now are same AM/PM. Fix for #12 since data type change didn't fix rollover issue. This introduces an edge case issue if alarm is set at an AM/PM switch-over time at 12 (Midnight or Noon). This can be worked around by choosing 1201 for alarm time.